### PR TITLE
feat: Add forgot password link to login page

### DIFF
--- a/Frontend/notes-frontend/src/sections/Login.jsx
+++ b/Frontend/notes-frontend/src/sections/Login.jsx
@@ -66,6 +66,11 @@ const Login = () => {
       <Text fontSize={"4xl"}>LOGIN</Text>
         <Input width={"350px"} mt="5%" name="email" onChange={handleChange} placeholder="type your email" />
         <Input width={"350px"} type="password" mt="5%" name="password" onChange={handleChange} placeholder="type your Password" />
+        <Box mt="2%" textAlign="right" width={"350px"}>
+          <NavLink to={"/forgot-password"}>
+            <Text fontSize={"sm"} color="blue.500">Forgot password?</Text>
+          </NavLink>
+        </Box>
         <Button size={"lg"} colorScheme="green" onClick={handleClick} display={"block"} m={"auto"} mt="3%">LOGIN</Button>
 
         <Box mt={"4%"} >


### PR DESCRIPTION
This PR adds a "Forgot password?" link to the login page as requested in Issue #53.

The link navigates to `/forgot-password`. No functional logic for password reset is included, as per the issue description. The link is styled to be consistent with the existing UI.