### PR TITLE
feat: add forgot password link to login page

### DIFF
--- a/Frontend/notes-frontend/src/sections/Login.jsx
+++ b/Frontend/notes-frontend/src/sections/Login.jsx
@@ -66,6 +66,11 @@ const Login = () => {
       <Text fontSize={"4xl"}>LOGIN</Text>
         <Input width={"350px"} mt="5%" name="email" onChange={handleChange} placeholder="type your email" />
         <Input width={"350px"} type="password" mt="5%" name="password" onChange={handleChange} placeholder="type your Password" />
+        <Box width={"350px"} m="auto" mt="2%" textAlign="right">
+             <NavLink to={"/request-password-reset"}>
+                 <Text color="Highlight" fontSize="sm">Forgot password?</Text>
+             </NavLink>
+        </Box>
         <Button size={"lg"} colorScheme="green" onClick={handleClick} display={"block"} m={"auto"} mt="3%">LOGIN</Button>
 
         <Box mt={"4%"} >


### PR DESCRIPTION
## Summary
- Added a "Forgot password?" link to the login page.
- The link is positioned directly below the password input field and right-aligned.
- It navigates to `/request-password-reset`.

## Changes
- Modified `Frontend/notes-frontend/src/sections/Login.jsx` to include the `NavLink`.