### PR TITLE
feat: add forgot password link to login page

### DIFF
--- a/Frontend/notes-frontend/src/sections/AllRoutes.jsx
+++ b/Frontend/notes-frontend/src/sections/AllRoutes.jsx
@@ -5,6 +5,7 @@ import EditNote from './EditNote'
 import HomePage from './HomePage'
 import Login from './Login'
 import NotesApp from './NotesApp'
+import RequestPasswordReset from './RequestPasswordReset'
 import Signup from './Signup'
 import {AnimatePresence} from "framer-motion"
 import PageNotFound from './PageNotFound'
@@ -19,6 +20,7 @@ export const AllRoutes = () => {
         <Route path='/' element={<HomePage/>} />
         <Route path='/signup' element={<Signup/>} />
         <Route path='/login' element={<Login/>} />
+        <Route path='/reset-password' element={<RequestPasswordReset/>} />
         <Route path='/notes' element={<ReqAuth><NotesApp/></ReqAuth>} />
         <Route path='/update/:id' element={<ReqAuth><EditNote/></ReqAuth>}/>
         <Route path='*' element={<PageNotFound/>} />

--- a/Frontend/notes-frontend/src/sections/Login.jsx
+++ b/Frontend/notes-frontend/src/sections/Login.jsx
@@ -1,4 +1,4 @@
-import { Box, Button, Input, Text, useToast } from '@chakra-ui/react'
+import { Box, Button, Input, Link, Text, useToast } from '@chakra-ui/react'
 import React from 'react'
 import { useState } from 'react'
 import { useDispatch } from 'react-redux'
@@ -66,6 +66,7 @@ const Login = () => {
       <Text fontSize={"4xl"}>LOGIN</Text>
         <Input width={"350px"} mt="5%" name="email" onChange={handleChange} placeholder="type your email" />
         <Input width={"350px"} type="password" mt="5%" name="password" onChange={handleChange} placeholder="type your Password" />
+        <Link onClick={() => Navigate('/reset-password')} mt="2%" display="block" textAlign="center" color="blue.500">Forgot password?</Link>
         <Button size={"lg"} colorScheme="green" onClick={handleClick} display={"block"} m={"auto"} mt="3%">LOGIN</Button>
 
         <Box mt={"4%"} >

--- a/Frontend/notes-frontend/src/sections/Login.test.js
+++ b/Frontend/notes-frontend/src/sections/Login.test.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Login from './Login';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+describe('Login Component', () => {
+  test('renders forgot password link', () => {
+    render(
+      <BrowserRouter>
+        <Login />
+      </BrowserRouter>
+    );
+
+    const forgotLink = screen.getByText('Forgot password?');
+    expect(forgotLink).toBeInTheDocument();
+  });
+
+  test('forgot password link navigates to reset-password', () => {
+    render(
+      <BrowserRouter>
+        <Login />
+      </BrowserRouter>
+    );
+
+    const forgotLink = screen.getByText('Forgot password?');
+    fireEvent.click(forgotLink);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/reset-password');
+  });
+});

--- a/Frontend/notes-frontend/src/sections/RequestPasswordReset.jsx
+++ b/Frontend/notes-frontend/src/sections/RequestPasswordReset.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Text } from '@chakra-ui/react'
+import Glass from './Glass'
+import Navbar from './Navbar'
+
+const RequestPasswordReset = () => {
+  return (
+    <div>
+      <Navbar />
+      <Glass>
+        <Text fontSize="4xl">Request Password Reset</Text>
+        <Text mt="4%">This feature is coming soon.</Text>
+      </Glass>
+    </div>
+  )
+}
+
+export default RequestPasswordReset

--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,8 @@
 
   ![Screenshot (147)](https://user-images.githubusercontent.com/101392591/196043479-39502424-bf84-42d6-8bd7-f760772bdc8c.png)
 
+  The login page includes a "Forgot password?" link below the password field to initiate password reset.
+
 
 - *Notes Page*
 


### PR DESCRIPTION
## Summary\n\n- Added a "Forgot password?" link directly below the password field on the login page.\n- The link navigates to a placeholder `/reset-password` route.\n- Created a stub component for the password reset screen.\n- Added unit tests to verify the link renders and navigates correctly.\n- Updated README.md to document the new feature.\n\nThis implements the acceptance criteria for issue #65.