### PR TITLE
Feat: Truncate note description and add Read More link

### DIFF
--- a/Frontend/notes-frontend/src/components/SingleNote.jsx
+++ b/Frontend/notes-frontend/src/components/SingleNote.jsx
@@ -47,9 +47,17 @@ export const SingleNote = ({heading,description,tag,id}) => {
               <Box  borderTopRightRadius="10px" borderTopLeftRadius={"10px"}  >
                 <Text fontSize={"xl"} color={"black"}>{heading}</Text>
               </Box> 
-              <Box  >
-                <Text fontSize={"md"} color={"white"}>{description}</Text>
-              </Box>  
+              <Box>
+                <Text fontSize={"md"} color={"white"}>
+                  {description.length > 50 ? (
+                    <>
+                      {description.substring(0, 50)}... <Link to={`/update/${id}`} style={{ color: 'teal' }}>Read More</Link>
+                    </>
+                  ) : (
+                    description
+                  )}
+                </Text>
+              </Box>
               <Box  >
                 <Badge mr={"25%"}  fontSize={"lg"} color={"orange.700"}>{tag}</Badge>
               </Box> 


### PR DESCRIPTION
This PR resolves #229 by truncating the note description in the note list view and adding a "Read More" link to the full note page.